### PR TITLE
Added ability to restrict OAuth logins by domain name (and bugfixes)

### DIFF
--- a/app/config/default.php
+++ b/app/config/default.php
@@ -90,6 +90,7 @@ return array(
 		'ldapPassword'        => '',
 		'oauthGoogleId'       => '',
 		'oauthGoogleSecret'   => '',
+		'oauthAppsDomains'    => '',
 		'oauthGoogleAdmins'   => '',
 	),
 

--- a/app/lang/en/admin.php
+++ b/app/lang/en/admin.php
@@ -212,6 +212,8 @@ return array(
 	"client_id"             => "Client ID",
 	"client_secret"         => "Client secret",
 	"client_secret_exp"     => "You can generate client ID and secret key at the",
+	"apps_domains"          => "Apps Domains",
+	"apps_domains_exp"      => "Restrict oAuth logins to these Google Apps domains",
 	"admin_emails"          => "Admin emails",
 	"admin_emails_exp"      => "Users with these email addresses will be granted admin access. Please enter one email ".
 	                           "address per line.",

--- a/app/views/skins/bootstrap/admin/auth.blade.php
+++ b/app/views/skins/bootstrap/admin/auth.blade.php
@@ -361,6 +361,26 @@
 
 							<div class="form-group">
 								{{
+									Form::label('oauth_apps_domains', Lang::get('admin.apps_domains'), array(
+										'class' => 'control-label col-sm-3 col-lg-2'
+									))
+								}}
+
+								<div class="col-sm-9 col-lg-10">
+									{{
+										Form::textarea('oauth_apps_domains', $site->auth->oauthAppsDomains, array(
+											'class' => 'form-control',
+											'rows'  => 3,
+										))
+									}}
+									<div class="help-block">
+										{{ Lang::get('admin.apps_domains_exp') }}
+									</div>
+								</div>
+							</div>
+
+							<div class="form-group">
+								{{
 									Form::label('oauth_google_admins', Lang::get('admin.admin_emails'), array(
 										'class' => 'control-label col-sm-3 col-lg-2'
 									))

--- a/app/views/skins/neverland/admin/auth.blade.php
+++ b/app/views/skins/neverland/admin/auth.blade.php
@@ -358,6 +358,26 @@
 								</div>
 							</div>
 
+							<div class="form-group">															  
+								{{																				
+									Form::label('oauth_apps_domains', Lang::get('admin.apps_domains'), array(	 
+										'class' => 'control-label col-sm-3 col-lg-2'							  
+									))																			
+								}}																				
+																												  
+								<div class="col-sm-9 col-lg-10">												  
+									{{																			
+										Form::textarea('oauth_apps_domains', $site->auth->oauthAppsDomains, array(
+											'class' => 'form-control',											
+											'rows'  => 3,														 
+										))																		
+									}}																			
+									<div class="help-block">													  
+										{{ Lang::get('admin.apps_domains_exp') }}								 
+									</div>																		
+								</div>																			
+							</div>																				
+
 							<div class="control-group">
 								{{
 									Form::label('oauth_google_admins', Lang::get('admin.admin_emails'), array(


### PR DESCRIPTION
 - Added ability to restrict OAuth logins by domain name.  
 - User display names now get populated.  
 - Fixed a bug where multiple admin email addresses would fail to match all but the last match (looks like there was some mystery whitespace left over and the end of the strings after the explode).
 - Removed the 'groups_provisioning' permission from the google auth request, as it doesn't appear to be used and forces the user to click through an additional screen.