### PR TITLE
Fix uniform-variable accesses for PHP7

### DIFF
--- a/app/lib/View.php
+++ b/app/lib/View.php
@@ -276,7 +276,7 @@ class View extends \Illuminate\Support\Facades\View {
 							// evaluate to true
 							if ( ! is_null($flags))
 							{
-								$visible = ($visible OR ($flags->$components[1] == $value XOR $invert));
+								$visible = ($visible OR ($flags->{$components[1]} == $value XOR $invert));
 							}
 						}
 

--- a/app/models/Site.php
+++ b/app/models/Site.php
@@ -75,7 +75,7 @@ class Site extends Eloquent {
 					{
 						foreach ($siteConfig as $item)
 						{
-							$config[$item['group']]->$item['key'] = $item['value'];
+							$config[$item['group']]->{$item['key']} = $item['value'];
 						}
 					}
 				}


### PR DESCRIPTION
Makes sticky-notes work with PHP7 for me.